### PR TITLE
README: set PATH_TO_PROJECTS as an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ Launch new Multipass virtual machine. **Note:** Setting the desired machine name
 
 ```sh
 $ export MACHINE_NAME="my-docker"
+$ export PATH_TO_PROJECTS="/path/to/projects"
 
 $ multipass launch \
   --cloud-init ./cloud-init-docker.yaml \
-  --mount /path/to/projects \
+  --mount $PATH_TO_PROJECTS \
   --name $MACHINE_NAME \
     20.04
 


### PR DESCRIPTION
This tripped me up: I set `MACHINE_NAME` then blindly copy-and-pasted the command.