### PR TITLE
README, cli-install.sh: Add a link to jq

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Overview of [`cloud-init-docker.yaml`](cloud-init-docker.yaml) tasks:
 - A series of `runcmd` commands to install required Docker Engine packages.
 - An addition of a `/etc/systemd/system/docker.service.d/httpapi.conf` systemd unit drop-in, which will start `/usr/bin/dockerd` with the HTTP API listening on all networks.
 
-Next, we will install `docker` and `docker-compose` CLI tools to the macOS _host_ via the [`cli-install.sh`](cli-install.sh) script:
+Next, we will install `docker` and `docker-compose` CLI tools to the macOS _host_ via the [`cli-install.sh`](cli-install.sh) script. Note that this script requires [`jq`](https://stedolan.github.io/jq/).
 
 ```sh
 $ ./cli-install.sh

--- a/cli-install.sh
+++ b/cli-install.sh
@@ -10,7 +10,7 @@ fi
 
 function main {
 	if [[ ! -x $(command -v jq) ]]; then
-		echo "Error: expecting to find jq" >&2
+		echo "Error: expecting to find jq, see https://stedolan.github.io/jq/" >&2
 		exit 1
 	fi
 


### PR DESCRIPTION
I found myself running this on a new system before I had bothered to install `jq`. This commit adds a mention of the dependency to the README and a link to the project page in the install script.